### PR TITLE
Deprecated ioutil  & os.CreateTemp

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -6,7 +6,6 @@ package browser
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -30,7 +29,7 @@ func OpenFile(path string) error {
 // OpenReader consumes the contents of r and presents the
 // results in a new browser window.
 func OpenReader(r io.Reader) error {
-	f, err := ioutil.TempFile("", "browser")
+	f, err := os.CreateTemp("", "browser")
 	if err != nil {
 		return fmt.Errorf("browser: could not create temporary file: %w", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/cli/browser
 
-go 1.13
+go 1.20
 
-require golang.org/x/sys v0.0.0-20210319071255-635bc2c9138d
+require golang.org/x/sys v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
+golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-golang.org/x/sys v0.0.0-20210319071255-635bc2c9138d h1:jbzgAvDZn8aEnytae+4ou0J0GwFZoHR0hOrTg4qH8GA=
-golang.org/x/sys v0.0.0-20210319071255-635bc2c9138d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations [should be preferred](https://pkg.go.dev/io/ioutil) in new code. See the specific function documentation for details. 

TempFile is deprecated : [As of Go 1.17, this function simply calls os.CreateTemp. ](https://pkg.go.dev/io/ioutil#TempFile)