### PR TITLE
Attempt to use `explorer.exe` on `http|https`

### DIFF
--- a/browser_linux.go
+++ b/browser_linux.go
@@ -5,9 +5,23 @@ import (
 	"strings"
 )
 
+// providersForUrl returns a slice of possible providers to open a browser on linux. The
+// order is from most to least preferred.
+func providersForUrl(url string) []string {
+	base := []string{"xdg-open", "x-www-browser", "www-browser"}
+	// explorer.exe is available in WSL. It can open http:// and https://, but not
+	// file://. explorer.exe is preferred over wslview for performance and to avoid
+	// redundant requests.
+	if strings.HasPrefix(url, "http://") || strings.HasPrefix(url, "https://") {
+		base = append(base, "explorer.exe", "wslview")
+	} else {
+		base = append(base, "wslview")
+	}
+	return base
+}
+
 func openBrowser(url string) error {
-	// explorer.exe is used for compatibility with Windows Subsystem for Linux
-	providers := []string{"xdg-open", "x-www-browser", "www-browser", "explorer.exe"}
+	providers := providersForUrl(url)
 
 	// There are multiple possible providers to open a browser on linux
 	// One of them is xdg-open, another is x-www-browser, then there's www-browser, etc.

--- a/browser_linux.go
+++ b/browser_linux.go
@@ -6,7 +6,8 @@ import (
 )
 
 func openBrowser(url string) error {
-	providers := []string{"xdg-open", "x-www-browser", "www-browser", "wslview"}
+	// explorer.exe is used for compatibility with Windows Subsystem for Linux
+	providers := []string{"xdg-open", "x-www-browser", "www-browser", "explorer.exe"}
 
 	// There are multiple possible providers to open a browser on linux
 	// One of them is xdg-open, another is x-www-browser, then there's www-browser, etc.

--- a/browser_linux_test.go
+++ b/browser_linux_test.go
@@ -1,0 +1,44 @@
+package browser
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestProvidersForUrl(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want []string
+	}{
+		{
+			name: "http protocol",
+			url:  "http://example.com",
+			want: []string{"xdg-open", "x-www-browser", "www-browser", "explorer.exe", "wslview"},
+		},
+		{
+			name: "https protocol",
+			url:  "https://example.com",
+			want: []string{"xdg-open", "x-www-browser", "www-browser", "explorer.exe", "wslview"},
+		},
+		{
+			name: "file protocol",
+			url:  "file:///path/to/file",
+			want: []string{"xdg-open", "x-www-browser", "www-browser", "wslview"},
+		},
+		{
+			name: "no protocol",
+			url:  "example.sh",
+			want: []string{"xdg-open", "x-www-browser", "www-browser", "wslview"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := providersForUrl(tt.url)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("providersForUrl(%q) = %v; want %v", tt.url, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Part of my motivation of this PR is to start a conversation on this.

After noticing that `wslview` felt really slow, I looked into the source code to see what the cause was. I noticed that `wslview` was doing a lot of stuff which, IMO, is unnecessary for the purposes of `gh`.

What `wslview` does is:

* Queries the Windows Registry via `reg.exe` to check if the build number is high enough (not used when opening URLs)
* Validates the URL by `curl`ing it and asserting that content was returned (a potential source of slowness, this can be skipped with `--skip-validation-check` on newer versions of `wslview`).

And, after these validations, what it boils down to is calling either `/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -Command "explorer.exe $URL"` or `/mnt/c/Windows/System32/cmd.exe /c explorer.exe "$URL"`. Starting a PowerShell process seems to contribute a lot to the slowness.

There's a bit of extra work in case a different prefix is used than `/mnt` or Windows is installed to a different drive than `C:`, but this should sum up the vast majority of cases.

I think these validations aren't necessary as long as `LookPath` is used, and `explorer.exe` can be called directly. I've noticed a pretty decent gain in speed when using `GH_BROWSER=explorer.exe` over `GH_BROWSER=wslview`.