### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: "daily"
+  cooldown:
+    default-days: 5
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - version-update:semver-major
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  cooldown:
+    default-days: 5


### PR DESCRIPTION
Adds a `.github/dependabot.yml` mirroring the configuration in [cli/oauth](https://github.com/cli/oauth/blob/main/.github/dependabot.yml):

- Daily `gomod` updates with a 5-day cooldown, ignoring major version bumps
- Daily `github-actions` updates with a 5-day cooldown