### PR TITLE
Harden CI workflow per zizmor

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,6 +1,10 @@
 on: [push, pull_request]
 
 name: CI
+
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:
@@ -13,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Setup go
         uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
Fixes the two zizmor findings on `.github/workflows/push.yml`:

- **excessive-permissions** — added top-level `permissions: contents: read` so the workflow no longer runs with default-write `GITHUB_TOKEN` scopes. The job only checks out code and runs `go test`; read is sufficient.
- **artipacked** — added `with: persist-credentials: false` to the checkout step so the token isn't persisted into `.git/config`, eliminating a credential-leak vector if a later step ever uploads artifacts.

## Verification

Run `zizmor` with the config below; expect zero findings:

```yaml
rules:
  unpinned-uses:
    config:
      policies:
        # First-party GitHub-maintained orgs: tag pins are acceptable.
        # Releases from these orgs are signed, retag risk is low, and patch
        # bumps for free outweigh the SHA-pin defense-in-depth here.
        actions/*: ref-pin
        github/*: ref-pin
        dependabot/*: ref-pin
        # Our own shared workflows repo: branch/tag refs are acceptable.
        desktop/gh-cli-and-desktop-shared-workflows/*: ref-pin
        # Everything else must be SHA-pinned.
        "*": hash-pin
  dependabot-cooldown:
    config:
      days: 5
```

```console
$ zizmor --config <above> .
No findings to report. Good job!
```

`go test ./...` still passes.
