### PR TITLE
feat: Add context-aware functions

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -4,6 +4,7 @@
 package browser
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -19,16 +20,29 @@ var Stderr io.Writer = os.Stderr
 
 // OpenFile opens new browser window for the file path.
 func OpenFile(path string) error {
+	return OpenFileContext(context.Background(), path)
+}
+
+// OpenFileContext opens new browser window for the file path.
+// Accepts a context.Context to allow for cancelling the operation.
+func OpenFileContext(ctx context.Context, path string) error {
 	path, err := filepath.Abs(path)
 	if err != nil {
 		return err
 	}
-	return OpenURL("file://" + path)
+	return OpenURLContext(ctx, "file://"+path)
 }
 
 // OpenReader consumes the contents of r and presents the
 // results in a new browser window.
 func OpenReader(r io.Reader) error {
+	return OpenReaderContext(context.Background(), r)
+}
+
+// OpenReaderContext consumes the contents of r and presents the
+// results in a new browser window.
+// Accepts a context.Context to allow for cancelling the operation.
+func OpenReaderContext(ctx context.Context, r io.Reader) error {
 	f, err := os.CreateTemp("", "browser.*.html")
 	if err != nil {
 		return fmt.Errorf("browser: could not create temporary file: %w", err)
@@ -40,16 +54,25 @@ func OpenReader(r io.Reader) error {
 	if err := f.Close(); err != nil {
 		return fmt.Errorf("browser: caching temporary file failed: %w", err)
 	}
-	return OpenFile(f.Name())
+	return OpenFileContext(ctx, f.Name())
 }
 
 // OpenURL opens a new browser window pointing to url.
 func OpenURL(url string) error {
-	return openBrowser(url)
+	return OpenURLContext(context.Background(), url)
 }
 
-func runCmd(prog string, args ...string) error {
-	cmd := exec.Command(prog, args...)
+// OpenURLContext opens a new browser window pointing to url.
+// Accepts a context.Context to allow for cancelling the operation.
+func OpenURLContext(ctx context.Context, url string) error {
+	return openBrowser(ctx, url)
+}
+
+func runCmd(ctx context.Context, prog string, args ...string) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cmd := exec.CommandContext(ctx, prog, args...)
 	cmd.Stdout = Stdout
 	cmd.Stderr = Stderr
 	return cmd.Run()

--- a/browser_darwin.go
+++ b/browser_darwin.go
@@ -1,5 +1,7 @@
 package browser
 
-func openBrowser(url string) error {
-	return runCmd("open", url)
+import "context"
+
+func openBrowser(ctx context.Context, url string) error {
+	return runCmd(ctx, "open", url)
 }

--- a/browser_freebsd.go
+++ b/browser_freebsd.go
@@ -1,13 +1,14 @@
 package browser
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
 )
 
-func openBrowser(url string) error {
-	err := runCmd("xdg-open", url)
+func openBrowser(ctx context.Context, url string) error {
+	err := runCmd(ctx, "xdg-open", url)
 	if errors.Is(err, exec.ErrNotFound) {
 		return fmt.Errorf("%w - install xdg-utils from ports(8)", err)
 	}

--- a/browser_linux.go
+++ b/browser_linux.go
@@ -1,11 +1,12 @@
 package browser
 
 import (
+	"context"
 	"os/exec"
 	"strings"
 )
 
-func openBrowser(url string) error {
+func openBrowser(ctx context.Context, url string) error {
 	providers := []string{"xdg-open", "x-www-browser", "www-browser", "wslview"}
 
 	// There are multiple possible providers to open a browser on linux
@@ -13,7 +14,7 @@ func openBrowser(url string) error {
 	// Look for one that exists and run it
 	for _, provider := range providers {
 		if _, err := exec.LookPath(provider); err == nil {
-			return runCmd(provider, url)
+			return runCmd(ctx, provider, url)
 		}
 	}
 

--- a/browser_netbsd.go
+++ b/browser_netbsd.go
@@ -1,12 +1,13 @@
 package browser
 
 import (
+	"context"
 	"errors"
 	"os/exec"
 )
 
-func openBrowser(url string) error {
-	err := runCmd("xdg-open", url)
+func openBrowser(ctx context.Context, url string) error {
+	err := runCmd(ctx, "xdg-open", url)
 	if e, ok := err.(*exec.Error); ok && e.Err == exec.ErrNotFound {
 		return errors.New("xdg-open: command not found - install xdg-utils from pkgsrc(7)")
 	}

--- a/browser_openbsd.go
+++ b/browser_openbsd.go
@@ -1,13 +1,14 @@
 package browser
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
 )
 
-func openBrowser(url string) error {
-	err := runCmd("xdg-open", url)
+func openBrowser(ctx context.Context, url string) error {
+	err := runCmd(ctx, "xdg-open", url)
 	if errors.Is(err, exec.ErrNotFound) {
 		return fmt.Errorf("%w - install xdg-utils from ports(8)", err)
 	}

--- a/browser_unsupported.go
+++ b/browser_unsupported.go
@@ -1,12 +1,14 @@
+//go:build !linux && !windows && !darwin && !openbsd && !freebsd && !netbsd
 // +build !linux,!windows,!darwin,!openbsd,!freebsd,!netbsd
 
 package browser
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 )
 
-func openBrowser(url string) error {
+func openBrowser(_ context.Context, _ string) error {
 	return fmt.Errorf("openBrowser: unsupported operating system: %v", runtime.GOOS)
 }

--- a/browser_windows.go
+++ b/browser_windows.go
@@ -1,7 +1,11 @@
 package browser
 
-import "golang.org/x/sys/windows"
+import (
+	"context"
 
-func openBrowser(url string) error {
+	"golang.org/x/sys/windows"
+)
+
+func openBrowser(_ context.Context, url string) error {
 	return windows.ShellExecute(0, nil, windows.StringToUTF16Ptr(url), nil, nil, windows.SW_SHOWNORMAL)
 }

--- a/example_test.go
+++ b/example_test.go
@@ -1,9 +1,12 @@
 package browser
 
-import "strings"
+import (
+	"context"
+	"strings"
+)
 
 func ExampleOpenFile() {
-	_ = OpenFile("index.html")
+	_ = OpenFileContext(context.Background(), "index.html")
 }
 
 func ExampleOpenReader() {
@@ -14,10 +17,10 @@ Perceptions of the most maddeningly untransmissible sort thronged upon us;
 perceptions of infinity which at the time convulsed us with joy, yet which
 are now partly lost to my memory and partly incapable of presentation to others.`
 	r := strings.NewReader(quote)
-	_ = OpenReader(r)
+	_ = OpenReaderContext(context.Background(), r)
 }
 
 func ExampleOpenURL() {
 	const url = "http://golang.org/"
-	_ = OpenURL(url)
+	_ = OpenURLContext(context.Background(), url)
 }


### PR DESCRIPTION
In rare cases, where `xdg-open` hangs, kill it if context is canceled.